### PR TITLE
Build out CSV format validators

### DIFF
--- a/lib/darlingtonia/validator.rb
+++ b/lib/darlingtonia/validator.rb
@@ -3,6 +3,19 @@
 module Darlingtonia
   ##
   # @abstract A null validator; always returns an empty error collection
+  #
+  # @example validating a parser
+  #   validator = MyValidator.new
+  #   validator.validate(parser: myParser)
+  #
+  # @example validating an invalid parser
+  #   validator = MyValidator.new
+  #   validator.validate(parser: invalidParser)
+  #   # => Error<#... validator: MyValidator,
+  #                   name: 'An Error Name',
+  #                   description: '...'
+  #                   lineno: 37>
+  #
   class Validator
     Error = Struct.new(:validator, :name, :description, :lineno)
 

--- a/lib/darlingtonia/validators/csv_format_validator.rb
+++ b/lib/darlingtonia/validators/csv_format_validator.rb
@@ -2,7 +2,23 @@
 
 module Darlingtonia
   ##
-  # A validator for correctly formatted CSV
+  # A validator for correctly formatted CSV.
+  #
+  # @example
+  #   parser = Parser.new(file: File.open('path/to/my.csv'))
+  #
+  #   CsvFormatValidator.new.validate(parser: parser)
+  #
+  # @see http://ruby-doc.org/stdlib-2.0.0/libdoc/csv/rdoc/CSV/MalformedCSVError.html
   class CsvFormatValidator < Validator
+    ##
+    # @see Validator#validate
+    def validate(parser:, **)
+      return [] if CSV.parse(parser.file.read)
+    rescue CSV::MalformedCSVError => e
+      [Error.new(self.class, e.class, e.message)]
+    ensure
+      parser.file.rewind
+    end
   end
 end

--- a/spec/darlingtonia/csv_format_validator_spec.rb
+++ b/spec/darlingtonia/csv_format_validator_spec.rb
@@ -3,5 +3,36 @@
 require 'spec_helper'
 
 describe Darlingtonia::CsvFormatValidator do
-  it_behaves_like 'a Darlingtonia::Validator'
+  subject(:validator)  { described_class.new }
+  let(:invalid_parser) { Darlingtonia::CsvParser.new(file: invalid_file) }
+  let(:invalid_file)   { File.open('spec/fixtures/bad_example.csv') }
+
+  it_behaves_like 'a Darlingtonia::Validator' do
+    let(:valid_parser)   { Darlingtonia::CsvParser.new(file: valid_file) }
+    let(:valid_file)     { File.open('spec/fixtures/example.csv') }
+  end
+
+  define :a_validator_error do
+    match do |error|
+      return false unless error.respond_to?(:validator)
+
+      if fields
+        return false if fields[:validator] && error.validator != fields[:validator]
+        return false if fields[:name]      && error.name      != fields[:name]
+      end
+
+      true
+    end
+
+    chain :with, :fields
+  end
+
+  describe '#validate' do
+    it 'returns a Validator::Error' do
+      expect(validator.validate(parser: invalid_parser))
+        .to contain_exactly a_validator_error
+        .with(validator: validator.class,
+              name:      CSV::MalformedCSVError)
+    end
+  end
 end

--- a/spec/darlingtonia/csv_parser_spec.rb
+++ b/spec/darlingtonia/csv_parser_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tempfile'
 
 describe Darlingtonia::CsvParser do
   subject(:parser) { described_class.new(file: file) }

--- a/spec/fixtures/bad_example.csv
+++ b/spec/fixtures/bad_example.csv
@@ -1,0 +1,2 @@
+title,description
+fake title, "fake description--quote wrap after delimiter then space is invalid"


### PR DESCRIPTION
This validator checks that a CSV file is properly formatted. It uses `MalformedCSVError` to supply relevant information to the user.

See: http://ruby-doc.org/stdlib-2.0.0/libdoc/csv/rdoc/CSV/MalformedCSVError.html