### PR TITLE
Fix `Parser` subclass registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+0.1.1 - Fri Jan 12, 2018
+------------------------
+
+Bugfix for nested class inheritance.
+
+- Fix CI by requiring manually 'tempfile' in specs that use it
+- Add a CSV format validator at `CsvFormatValidator`
+- Fix `Parser` subclass registration and reorder parser class `#match`
+  priority.
+
+0.1.0 - Thu Jan 11, 2018
+------------------------
+
+Inital release.

--- a/lib/darlingtonia/parser.rb
+++ b/lib/darlingtonia/parser.rb
@@ -9,8 +9,10 @@ module Darlingtonia
   #
   #   Parser.for(file: file).records
   #
+  # rubocop:disable Style/ClassVars
   class Parser
-    @subclasses = [] # @private
+    DEFAULT_VALIDATORS = [].freeze
+    @@subclasses = [] # @private
 
     ##
     # @!attribute [rw] file
@@ -42,7 +44,7 @@ module Darlingtonia
       # @raise [NoParserError]
       def for(file:)
         klass =
-          @subclasses.find { |k| k.match?(file: file) } ||
+          @@subclasses.find { |k| k.match?(file: file) } ||
           raise(NoParserError)
 
         klass.new(file: file)
@@ -58,7 +60,7 @@ module Darlingtonia
       ##
       # @private Register a new class when inherited
       def inherited(subclass)
-        @subclasses << subclass
+        @@subclasses.unshift subclass
         super
       end
     end
@@ -99,5 +101,5 @@ module Darlingtonia
 
     class NoParserError < TypeError; end
     class ValidationError < RuntimeError; end
-  end
+  end # rubocop:enable Style/ClassVars
 end

--- a/lib/darlingtonia/version.rb
+++ b/lib/darlingtonia/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Darlingtonia
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/darlingtonia/parser_spec.rb
+++ b/spec/darlingtonia/parser_spec.rb
@@ -24,12 +24,17 @@ describe Darlingtonia::Parser do
             end
           end
         end
+
+        class NestedParser < FakeParser; end
       end
 
-      after(:context) { Object.send(:remove_const, :FakeParser) }
+      after(:context) do
+        Object.send(:remove_const, :FakeParser)
+        Object.send(:remove_const, :NestedParser)
+      end
 
       it 'returns an importer instance' do
-        expect(described_class.for(file: file)).to be_a FakeParser
+        expect(described_class.for(file: file)).to be_a NestedParser
       end
     end
   end


### PR DESCRIPTION
`@subclasses` was `nil` for subclasses of `Parser`, preventing them from being inherited. This ensures that subclassing and subclass registration works properly for nested subclasses by using a class variable, rather than a class instance variable.

We also *prepend*, instead of append, classes to the array. This way the most recently (which will tend to be the most locally) defined classes take precedence when looking for parser class matches.

**This also prepares a proposed 0.1.1 release.**