### PR TITLE
Validation error stream

### DIFF
--- a/lib/darlingtonia.rb
+++ b/lib/darlingtonia.rb
@@ -13,9 +13,9 @@ module Darlingtonia
 
   require 'darlingtonia/input_record'
 
-  require 'darlingtonia/parser'
-  require 'darlingtonia/parsers/csv_parser'
-
   require 'darlingtonia/validator'
   require 'darlingtonia/validators/csv_format_validator'
+
+  require 'darlingtonia/parser'
+  require 'darlingtonia/parsers/csv_parser'
 end

--- a/lib/darlingtonia/parser.rb
+++ b/lib/darlingtonia/parser.rb
@@ -29,7 +29,7 @@ module Darlingtonia
     def initialize(file:, **_opts)
       self.file     = file
       @errors       = []
-      @validators ||= []
+      @validators ||= self.class::DEFAULT_VALIDATORS
 
       yield self if block_given?
     end

--- a/lib/darlingtonia/parsers/csv_parser.rb
+++ b/lib/darlingtonia/parsers/csv_parser.rb
@@ -6,6 +6,7 @@ module Darlingtonia
   ##
   # A parser for CSV files
   class CsvParser < Parser
+    DEFAULT_VALIDATORS = [CsvFormatValidator.new].freeze
     EXTENSION = '.csv'
 
     class << self

--- a/lib/darlingtonia/validator.rb
+++ b/lib/darlingtonia/validator.rb
@@ -17,18 +17,42 @@ module Darlingtonia
   #                   lineno: 37>
   #
   class Validator
-    Error = Struct.new(:validator, :name, :description, :lineno)
+    Error = Struct.new(:validator, :name, :description, :lineno) do
+      def to_s
+        "#{name}: #{description} (#{validator})"
+      end
+    end
 
     ##
-    # @param parser       [Parser]
-    # @param error_stream [#add]
+    # @!attribute [rw] error_stream
+    #   @return [#<<]
+    attr_accessor :error_stream
+
+    ##
+    # @param error_stream [#<<]
+    def initialize(error_stream: STDOUT)
+      self.error_stream = error_stream
+    end
+
+    ##
+    # @param parser [Parser]
     #
     # @return [Enumerator<Error>] a collection of errors found in validation
-    #
-    # rubocop:disable Lint/UnusedMethodArgument
-    def validate(parser:, **)
-      []
+    def validate(parser:)
+      run_validation(parser: parser).tap do |errors|
+        errors.each { |error| error_stream << error }
+      end
     end
     # rubocop:enable Lint/UnusedMethodArgument
+
+    private
+
+      ##
+      # @return [Enumerator<Error>]
+      #
+      # rubocop:disable Lint/UnusedMethodArgument
+      def run_validation(parser:)
+        []
+      end
   end
 end

--- a/lib/darlingtonia/validators/csv_format_validator.rb
+++ b/lib/darlingtonia/validators/csv_format_validator.rb
@@ -12,8 +12,10 @@ module Darlingtonia
   # @see http://ruby-doc.org/stdlib-2.0.0/libdoc/csv/rdoc/CSV/MalformedCSVError.html
   class CsvFormatValidator < Validator
     ##
+    # @private
+    #
     # @see Validator#validate
-    def validate(parser:, **)
+    def run_validation(parser:, **)
       return [] if CSV.parse(parser.file.read)
     rescue CSV::MalformedCSVError => e
       [Error.new(self.class, e.class, e.message)]

--- a/spec/darlingtonia/csv_format_validator_spec.rb
+++ b/spec/darlingtonia/csv_format_validator_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Darlingtonia::CsvFormatValidator do
-  subject(:validator)  { described_class.new }
+  subject(:validator)  { described_class.new(error_stream: []) }
   let(:invalid_parser) { Darlingtonia::CsvParser.new(file: invalid_file) }
   let(:invalid_file)   { File.open('spec/fixtures/bad_example.csv') }
 

--- a/spec/darlingtonia/csv_parser_spec.rb
+++ b/spec/darlingtonia/csv_parser_spec.rb
@@ -46,4 +46,18 @@ EOS
       expect(parser.records.map(&:date)).to contain_exactly(['1945'], ['1946'])
     end
   end
+
+  describe '#validate' do
+    it 'is valid' do
+      expect(parser.validate).to be_truthy
+    end
+
+    context 'with invalid file' do
+      let(:file) { File.open('spec/fixtures/bad_example.csv') }
+
+      it 'is invalid' do
+        expect(parser.validate).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/darlingtonia/validator_spec.rb
+++ b/spec/darlingtonia/validator_spec.rb
@@ -3,5 +3,7 @@
 require 'spec_helper'
 
 describe Darlingtonia::Validator do
-  it_behaves_like 'a Darlingtonia::Validator'
+  it_behaves_like 'a Darlingtonia::Validator' do
+    let(:valid_parser) { :any }
+  end
 end

--- a/spec/integration/import_csv_spec.rb
+++ b/spec/integration/import_csv_spec.rb
@@ -35,4 +35,16 @@ describe 'importing a csv batch' do
   it 'creates a record for each CSV line' do
     expect { importer.import }.to change { Work.count }.to 3
   end
+
+  describe 'validation' do
+    context 'with invalid CSV' do
+      let(:file) { File.open('spec/fixtures/bad_example.csv') }
+
+      it 'outputs invalid file notice to error stream' do
+        expect { parser.validate }
+          .to output(/^CSV::MalformedCSVError.*line 2/)
+          .to_stdout_from_any_process
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/a_validator.rb
+++ b/spec/support/shared_examples/a_validator.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 shared_examples 'a Darlingtonia::Validator' do
-  subject(:validator) { described_class.new }
+  subject(:validator) { described_class.new(error_stream: error_stream) }
+  let(:error_stream)  { [] }
 
   define :be_a_validator_error do # |expected|
     match { false } # { |actual| some_condition }
@@ -30,6 +31,14 @@ shared_examples 'a Darlingtonia::Validator' do
 
         validator.validate(parser: invalid_parser).each do |error|
           expect(error).to be_a_validator_error
+        end
+      end
+
+      it 'writes errors to the error stream' do
+        if defined?(invalid_parser)
+          expect { validator.validate(parser: invalid_parser) }
+            .to change { error_stream }
+            .to include(an_instance_of(Darlingtonia::Validator::Error))
         end
       end
     end


### PR DESCRIPTION
Adds a single method interface for "ErrorStreams" (`#<<`). This is compatible
with `IO` and `Array`, which make for easy reuse of `STDOUT` and `Array` as easy
error stream classes. We will probably want to define a more complex
`ErrorStream` that accepts some kind of formattter for `Validation::Error`
etc...

Error output still needs to be handled for `RecordImporter`.

`Validator` subclasses now need to overwrite the private `#run_validation`
method to retain the default error streaming behavior.