### PR TITLE
Use `#map` instead of `#each` to stream errors

### DIFF
--- a/lib/darlingtonia/validator.rb
+++ b/lib/darlingtonia/validator.rb
@@ -40,7 +40,7 @@ module Darlingtonia
     # @return [Enumerator<Error>] a collection of errors found in validation
     def validate(parser:)
       run_validation(parser: parser).tap do |errors|
-        errors.each { |error| error_stream << error }
+        errors.map { |error| error_stream << error }
       end
     end
     # rubocop:enable Lint/UnusedMethodArgument
@@ -52,7 +52,7 @@ module Darlingtonia
       #
       # rubocop:disable Lint/UnusedMethodArgument
       def run_validation(parser:)
-        []
+        [].to_enum
       end
   end
 end

--- a/spec/support/shared_examples/a_validator.rb
+++ b/spec/support/shared_examples/a_validator.rb
@@ -16,13 +16,13 @@ shared_examples 'a Darlingtonia::Validator' do
     end
 
     it 'gives an empty error collection for a valid parser' do
-      expect(validator.validate(parser: valid_parser)).to be_empty if
+      expect(validator.validate(parser: valid_parser)).not_to be_any if
         defined?(valid_parser)
     end
 
     context 'for an invalid parser' do
       it 'gives an non-empty error collection' do
-        expect(validator.validate(parser: invalid_parser)).not_to be_empty if
+        expect(validator.validate(parser: invalid_parser)).to be_any if
           defined?(invalid_parser)
       end
 


### PR DESCRIPTION
This avoids trying to iterate repeatedly over the error `Enumerator`. The old behavior could be potentially costly for large error sets, and limits `Validator` behavior by requiring non-lazy enumerotors.