### PR TITLE
Add error handling for unexpected RuntimeErrors during import

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,10 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.3
 
+Lint/HandleExceptions:
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/lib/darlingtonia.rb
+++ b/lib/darlingtonia.rb
@@ -29,10 +29,13 @@ module Darlingtonia
     ##
     # @!attribute [rw] default_error_stream
     #   @return [#<<]
-    attr_accessor :default_error_stream
+    # @!attribute [rw] default_info_stream
+    #   @return [#<<]
+    attr_accessor :default_error_stream, :default_info_stream
 
     def initialize
       self.default_error_stream = STDOUT
+      self.default_info_stream  = STDOUT
     end
   end
 

--- a/lib/darlingtonia/record_importer.rb
+++ b/lib/darlingtonia/record_importer.rb
@@ -3,11 +3,25 @@
 module Darlingtonia
   class RecordImporter
     ##
+    # @!attribute [rw] error_stream
+    #   @return [#<<]
+    attr_accessor :error_stream
+
+    ##
+    # @param error_stream [#<<]
+    def initialize(error_stream: STDOUT)
+      self.error_stream = error_stream
+    end
+
+    ##
     # @param record [ImportRecord]
     #
     # @return [void]
     def import(record:)
       import_type.create(record.attributes)
+    rescue RuntimeError => e
+      error_stream << e
+      raise e
     end
 
     def import_type

--- a/lib/darlingtonia/record_importer.rb
+++ b/lib/darlingtonia/record_importer.rb
@@ -19,6 +19,8 @@ module Darlingtonia
     # @return [void]
     def import(record:)
       import_type.create(record.attributes)
+    rescue Faraday::ConnectionFailed, Ldp::HttpError => e
+      error_stream << e
     rescue RuntimeError => e
       error_stream << e
       raise e

--- a/spec/darlingtonia/record_importer_spec.rb
+++ b/spec/darlingtonia/record_importer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Darlingtonia::RecordImporter, :clean do
+  subject(:importer) { described_class.new(error_stream: error_stream) }
+  let(:error_stream) { [] }
+  let(:record)       { Darlingtonia::InputRecord.new }
+
+  it 'raises an error when no work type exists' do
+    expect { importer.import(record: record) }
+      .to raise_error 'No curation_concern found for import'
+  end
+
+  context 'with a registered work type' do
+    include_context 'with a work type'
+
+    it 'creates a work for record' do
+      expect { importer.import(record: record) }
+        .to change { Work.count }
+        .by 1
+    end
+
+    context 'when input record errors unexpectedly' do
+      let(:custom_error) { Class.new(RuntimeError) }
+
+      before { allow(record).to receive(:attributes).and_raise(custom_error) }
+
+      it 'writes errors to the error stream' do
+        expect { begin; importer.import(record: record); rescue; end }
+          .to change { error_stream }
+          .to contain_exactly(an_instance_of(custom_error))
+      end
+
+      it 'reraises error' do
+        expect { importer.import(record: record) }.to raise_error(custom_error)
+      end
+    end
+  end
+end

--- a/spec/darlingtonia/record_importer_spec.rb
+++ b/spec/darlingtonia/record_importer_spec.rb
@@ -3,8 +3,12 @@
 require 'spec_helper'
 
 describe Darlingtonia::RecordImporter, :clean do
-  subject(:importer) { described_class.new(error_stream: error_stream) }
+  subject(:importer) do
+    described_class.new(error_stream: error_stream, info_stream: info_stream)
+  end
+
   let(:error_stream) { [] }
+  let(:info_stream)  { [] }
   let(:record)       { Darlingtonia::InputRecord.new }
 
   it 'raises an error when no work type exists' do
@@ -19,6 +23,12 @@ describe Darlingtonia::RecordImporter, :clean do
       expect { importer.import(record: record) }
         .to change { Work.count }
         .by 1
+    end
+
+    it 'writes to the info stream before and after create' do
+      expect { importer.import(record: record) }
+        .to change { info_stream }
+        .to contain_exactly(/^Creating record/, /^Record created/)
     end
 
     context 'when input record errors with LDP errors' do

--- a/spec/darlingtonia/record_importer_spec.rb
+++ b/spec/darlingtonia/record_importer_spec.rb
@@ -21,6 +21,18 @@ describe Darlingtonia::RecordImporter, :clean do
         .by 1
     end
 
+    context 'when input record errors with LDP errors' do
+      let(:ldp_error) { Ldp::PreconditionFailed }
+
+      before { allow(record).to receive(:attributes).and_raise(ldp_error) }
+
+      it 'writes errors to the error stream (no reraise!)' do
+        expect { importer.import(record: record) }
+          .to change { error_stream }
+          .to contain_exactly(an_instance_of(ldp_error))
+      end
+    end
+
     context 'when input record errors unexpectedly' do
       let(:custom_error) { Class.new(RuntimeError) }
 

--- a/spec/darlingtonia_spec.rb
+++ b/spec/darlingtonia_spec.rb
@@ -12,5 +12,14 @@ describe Darlingtonia do
         .from(STDOUT)
         .to(stream)
     end
+
+    it 'can set a default info stream' do
+      stream = []
+
+      expect { described_class.config { |c| c.default_info_stream = stream } }
+        .to change { described_class.config.default_info_stream }
+        .from(STDOUT)
+        .to(stream)
+    end
   end
 end

--- a/spec/integration/import_csv_spec.rb
+++ b/spec/integration/import_csv_spec.rb
@@ -2,35 +2,12 @@
 
 require 'spec_helper'
 
-describe 'importing a csv batch' do
+describe 'importing a csv batch', :clean do
   subject(:importer) { Darlingtonia::Importer.new(parser: parser) }
   let(:parser)       { Darlingtonia::CsvParser.new(file: file) }
   let(:file)         { File.open('spec/fixtures/example.csv') }
 
-  # A work type must be defined for the default `RecordImporter` to save objects
-  before do
-    class Work < ActiveFedora::Base
-      property :title,       predicate: ::RDF::URI('http://example.com/title')
-      property :description, predicate: ::RDF::URI('http://example.com/description')
-    end
-
-    module Hyrax
-      def self.config
-        Config.new
-      end
-
-      class Config
-        def curation_concerns
-          [Work]
-        end
-      end
-    end
-  end
-
-  after do
-    Object.send(:remove_const, :Hyrax)
-    Object.send(:remove_const, :Work)
-  end
+  include_context 'with a work type'
 
   it 'creates a record for each CSV line' do
     expect { importer.import }.to change { Work.count }.to 3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'pry' unless ENV['CI']
 ENV['environment'] ||= 'test'
 
 require 'bundler/setup'
+require 'active_fedora/cleaner'
 require 'darlingtonia'
 
 Dir['./spec/support/**/*.rb'].each { |f| require f }
@@ -11,4 +12,6 @@ Dir['./spec/support/**/*.rb'].each { |f| require f }
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+
+  config.before(:each, clean: true) { ActiveFedora::Cleaner.clean! }
 end

--- a/spec/support/shared_contexts/with_work_type.rb
+++ b/spec/support/shared_contexts/with_work_type.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+shared_context 'with a work type' do
+  # A work type must be defined for the default `RecordImporter` to save objects
+  before do
+    class Work < ActiveFedora::Base
+      property :title,       predicate: ::RDF::URI('http://example.com/title')
+      property :description, predicate: ::RDF::URI('http://example.com/description')
+    end
+
+    module Hyrax
+      def self.config
+        Config.new
+      end
+
+      class Config
+        def curation_concerns
+          [Work]
+        end
+      end
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :Hyrax)
+    Object.send(:remove_const, :Work)
+  end
+end

--- a/spec/support/shared_contexts/with_work_type.rb
+++ b/spec/support/shared_contexts/with_work_type.rb
@@ -22,7 +22,7 @@ shared_context 'with a work type' do
   end
 
   after do
-    Object.send(:remove_const, :Hyrax)
-    Object.send(:remove_const, :Work)
+    Object.send(:remove_const, :Hyrax) if defined?(Hyrax)
+    Object.send(:remove_const, :Work)  if defined?(Work)
   end
 end


### PR DESCRIPTION
When running `RecordImporter#import` various errors are possible, through
`InputRecord`, or in identifying an import type, or otherwise during creation of
the object from the input record. When an error which is otherwise unhandled
reaches `#import` we send it to the `error_stream`, then re-raise.

Re-raising lets the error also reach the caller, which may have other handling,
or may want to abort further activity.

Errors caused by connection issues to Fedora are caught and logged, but not
reraised. This allows the records to continue to process.

----

b7432e2 adds notifications before and after creation to help track record progress.

Adds an `info_stream` to `RecordImporter`, which defaults to `STDOUT`. This
stream can be used to process informational notices.

Initial notices are added to the `#import` call to let the user know that a
record is being processed, and when it has been created. The title and id are
included in the pre- and post-create notices, respectively.