### PR TITLE
Support validation of presence of `title` in records

### DIFF
--- a/lib/darlingtonia.rb
+++ b/lib/darlingtonia.rb
@@ -49,6 +49,7 @@ module Darlingtonia
 
   require 'darlingtonia/validator'
   require 'darlingtonia/validators/csv_format_validator'
+  require 'darlingtonia/validators/title_validator'
 
   require 'darlingtonia/parser'
   require 'darlingtonia/parsers/csv_parser'

--- a/lib/darlingtonia/validators/title_validator.rb
+++ b/lib/darlingtonia/validators/title_validator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Darlingtonia
+  class TitleValidator < Validator
+    ##
+    # @private
+    #
+    # @see Validator#validate
+    def run_validation(parser:, **)
+      parser.records.each_with_object([]) do |record, errors|
+        titles = record.respond_to?(:title) ? record.title : []
+
+        errors << error_for(record: record) if Array(titles).empty?
+      end
+    end
+
+    protected
+
+      ##
+      # @private
+      # @param record [InputRecord]
+      #
+      # @return [Error]
+      def error_for(record:)
+        Error.new(self,
+                  :missing_title,
+                  "Title is required; got #{record.mapper.metadata}")
+      end
+  end
+end

--- a/spec/darlingtonia/parser_spec.rb
+++ b/spec/darlingtonia/parser_spec.rb
@@ -17,7 +17,7 @@ describe Darlingtonia::Parser do
       before(:context) do
         ##
         # An importer that matches all types
-        class FakeParser < described_class
+        class MyFakeParser < described_class
           class << self
             def match?(**_opts)
               true
@@ -25,11 +25,11 @@ describe Darlingtonia::Parser do
           end
         end
 
-        class NestedParser < FakeParser; end
+        class NestedParser < MyFakeParser; end
       end
 
       after(:context) do
-        Object.send(:remove_const, :FakeParser)
+        Object.send(:remove_const, :MyFakeParser)
         Object.send(:remove_const, :NestedParser)
       end
 

--- a/spec/darlingtonia/title_validator_spec.rb
+++ b/spec/darlingtonia/title_validator_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Darlingtonia::TitleValidator do
+  subject(:validator) { described_class.new(error_stream: []) }
+
+  let(:invalid_parser) do
+    FakeParser.new(file: [{ 'title' => 'moomin' }, {}, {}])
+  end
+
+  it_behaves_like 'a Darlingtonia::Validator' do
+    let(:valid_parser) { FakeParser.new(file: [{ 'title' => 'moomin' }]) }
+  end
+
+  describe '#validate' do
+    it 'populates errors for records with missing titles' do
+      expect(validator.validate(parser: invalid_parser))
+        .to contain_exactly(an_instance_of(described_class::Error),
+                            an_instance_of(described_class::Error))
+    end
+  end
+end


### PR DESCRIPTION
This is a generic `title` presence validitor. It generates validation errors for
each record in the parser that does not have a title.

The validation is done at the `InputRecord` level, so the information given is
sparse (no line numbers), but the individual record metadata is reported with
each error to help identify the source of the issues.