### PR TITLE
Ignore `pkg` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+pkg
 tmp
 Gemfile.lock


### PR DESCRIPTION
Building and releasing the gem results in a `./pkg` directory, which can be safely ignored, and is added to `.gitignore` here.