### PR TITLE
Yield empty parser on in invalid CSV case

### DIFF
--- a/lib/darlingtonia/parsers/csv_parser.rb
+++ b/lib/darlingtonia/parsers/csv_parser.rb
@@ -38,6 +38,8 @@ module Darlingtonia
       CSV.parse(file.read, headers: true).each do |row|
         yield InputRecord.from(metadata: row)
       end
+    rescue CSV::MalformedCSVError
+      []
     end
   end
 end

--- a/spec/darlingtonia/csv_parser_spec.rb
+++ b/spec/darlingtonia/csv_parser_spec.rb
@@ -34,16 +34,26 @@ EOS
   end
 
   describe '#records' do
-    include_context 'with content'
+    context 'with valid content' do
+      include_context 'with content'
 
-    it 'has the correct titles' do
-      expect(parser.records.map(&:title))
-        .to contain_exactly(['The Moomins and the Great Flood'],
-                            ['Comet in Moominland'])
+      it 'has the correct titles' do
+        expect(parser.records.map(&:title))
+          .to contain_exactly(['The Moomins and the Great Flood'],
+                              ['Comet in Moominland'])
+      end
+
+      it 'has correct other fields' do
+        expect(parser.records.map(&:date)).to contain_exactly(['1945'], ['1946'])
+      end
     end
 
-    it 'has correct other fields' do
-      expect(parser.records.map(&:date)).to contain_exactly(['1945'], ['1946'])
+    context 'with invalid file' do
+      let(:file) { File.open('spec/fixtures/bad_example.csv') }
+
+      it 'is empty' do
+        expect(parser.records.to_a).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
We want an empty parser in case of invalid CSV, so validators can consume the empty record stream instead of running into errors.