### PR TITLE
Support file mapping with `InputRecord#representative_file`

### DIFF
--- a/lib/darlingtonia/input_record.rb
+++ b/lib/darlingtonia/input_record.rb
@@ -30,6 +30,16 @@ module Darlingtonia
     end
 
     ##
+    # @return [String, nil] an identifier for the representative file; nil if
+    #   none is given.
+    def representative_file
+      return mapper.representative_file if
+        mapper.respond_to?(:representative_file)
+
+      nil
+    end
+
+    ##
     # Respond to methods matching mapper fields
     def method_missing(method_name, *args, &block)
       return super unless mapper.field?(method_name)

--- a/spec/darlingtonia/input_record_spec.rb
+++ b/spec/darlingtonia/input_record_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 describe Darlingtonia::InputRecord do
   subject(:record) { described_class.from(metadata: metadata) }
 
@@ -16,6 +18,30 @@ describe Darlingtonia::InputRecord do
   describe '#attributes' do
     it 'handles basic text fields' do
       expect(record.attributes).to include(:title, :description)
+    end
+
+    it 'does not include representative_file' do
+      expect(record.attributes).not_to include(:representative_file)
+    end
+  end
+
+  describe '#representative_file' do
+    it 'is nil if mapper does not provide a representative file' do
+      expect(record.representative_file).to be_nil
+    end
+
+    context 'when mapper provides representative_file' do
+      let(:representative_file) { :A_DUMMY_FILE }
+
+      before do
+        allow(record.mapper)
+          .to receive(:representative_file)
+          .and_return(representative_file)
+      end
+
+      it 'is the file from the mapper' do
+        expect(record.representative_file).to eql representative_file
+      end
     end
   end
 


### PR DESCRIPTION
`InputRecord#representative_file` returns `nil` if the mapper does not implement
`#representative_file`, else it passes through. This property is not added to
the attributes hash, instead acting as a special term.