### PR TITLE
Add YARD badge and API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 Darlingtonia
 ============
 
-Object import for Hyrax.
+[![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/gems/darlingtonia)
+
+Object import for Hyrax. See the [API documentation](http://www.rubydoc.info/gems/hyrax-spec) for more
+information.
 
 Usage
 -----


### PR DESCRIPTION
The badge is lifted from https://github.com/docmeta/rubydoc.info/issues/61.