### PR TITLE
Require active_fedora >= 12.0.2

### DIFF
--- a/darlingtonia.gemspec
+++ b/darlingtonia.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.3.4'
 
-  gem.add_dependency 'active-fedora', '>= 11.0', '<= 12.99'
+  gem.add_dependency 'active-fedora', '>= 12.0.2', '<= 12.99'
 
   gem.add_development_dependency 'yard',           '~> 0.9'
   gem.add_development_dependency 'bixby',          '~> 0.3'


### PR DESCRIPTION
This bypasses a critical active-fedora bug