### PR TITLE
Make HyraxBasicMetadataMapper the default mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ information.
 Usage
 -----
 
-In your project's `Gemfile`, add: `gem 'darlingtonia', '~> 0.1'`, then do `bundle install`.
+In your project's `Gemfile`, add: `gem 'darlingtonia', '~> 2.0'`, then do `bundle install`.
 
 
 This software is primarily intended for use in a [Hyrax](https://github.com/samvera/hyrax) project.
 However, its dependency on `hyrax` is kept strictly optional so most of its code can be reused to
-good effect elsewhere.
+good effect elsewhere. Note: As of release 2.0, `HyraxBasicMetadataMapper` will be the default mapper.
 
 To do a basic Hyrax import, first ensure that a [work type is registered](http://www.rubydoc.info/github/samvera/hyrax/Hyrax/Configuration#register_curation_concern-instance_method)
 with your `Hyrax` application. You need to provide a `Parser` (out of the box, we support simple CSV

--- a/lib/darlingtonia/input_record.rb
+++ b/lib/darlingtonia/input_record.rb
@@ -25,7 +25,7 @@ module Darlingtonia
       #
       # @return [InputRecord] an input record mapping metadata with the given
       #   mapper
-      def from(metadata:, mapper: HashMapper.new)
+      def from(metadata:, mapper: HyraxBasicMetadataMapper.new)
         mapper.metadata = metadata
         new(mapper: mapper)
       end

--- a/spec/darlingtonia/csv_parser_spec.rb
+++ b/spec/darlingtonia/csv_parser_spec.rb
@@ -11,7 +11,7 @@ describe Darlingtonia::CsvParser do
   shared_context 'with content' do
     let(:csv_content) do
       <<-EOS
-title,description,date
+title,description,date_created
 The Moomins and the Great Flood,"The Moomins and the Great Flood (Swedish: Småtrollen och den stora översvämningen, literally The Little Trolls and the Great Flood) is a book written by Finnish author Tove Jansson in 1945, during the end of World War II. It was the first book to star the Moomins, but is often seen as a prelude to the main Moomin books, as most of the main characters are introduced in the next book.",1945
 Comet in Moominland,"Comet in Moominland is the second in Tove Jansson's series of Moomin books. Published in 1946, it marks the first appearance of several main characters, like Snufkin and the Snork Maiden.",1946
 EOS
@@ -44,7 +44,7 @@ EOS
       end
 
       it 'has correct other fields' do
-        expect(parser.records.map(&:date)).to contain_exactly(['1945'], ['1946'])
+        expect(parser.records.map(&:date_created)).to contain_exactly(['1945'], ['1946'])
       end
     end
 

--- a/spec/darlingtonia/input_record_spec.rb
+++ b/spec/darlingtonia/input_record_spec.rb
@@ -12,7 +12,7 @@ describe Darlingtonia::InputRecord do
 
   it 'has metadata and a mapper' do
     is_expected
-      .to have_attributes(mapper: an_instance_of(Darlingtonia::HashMapper))
+      .to have_attributes(mapper: an_instance_of(Darlingtonia::HyraxBasicMetadataMapper))
   end
 
   describe '#attributes' do


### PR DESCRIPTION
Make HyraxBasicMetadataMapper the default mapper

This is a potentially breaking change so we should increment our major version number.