### PR TITLE
Allow HyraxRecordImporter to set a collection ID so that the new works will belong to that collection.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ Lint/HandleExceptions:
 Metrics/AbcSize:
   Exclude:
     - 'spec/support/hyrax/basic_metadata.rb'
+    - 'lib/darlingtonia/hyrax_record_importer.rb'
 
 Metrics/BlockLength:
   Exclude:

--- a/lib/darlingtonia/hyrax_record_importer.rb
+++ b/lib/darlingtonia/hyrax_record_importer.rb
@@ -8,12 +8,17 @@ module Darlingtonia
     # @!attribute [rw] creator
     #   @return [User]
     attr_accessor :creator
+    attr_accessor :collection_id
 
     ##
     # @param creator   [User]
-    def initialize(*)
+    def initialize(error_stream: Darlingtonia.config.default_error_stream,
+                   info_stream: Darlingtonia.config.default_info_stream,
+                   collection_id: nil)
       self.creator = ::User.find_or_create_system_user(DEFAULT_CREATOR_KEY)
-      super
+      self.collection_id = collection_id
+
+      super(error_stream: error_stream, info_stream: info_stream)
     end
 
     ##
@@ -81,7 +86,9 @@ module Darlingtonia
         set_depositor(record)
         uploaded_files = { uploaded_files: create_upload_files(record) }
         created    = import_type.new
+
         attributes = record.attributes.merge(uploaded_files)
+        attributes = attributes.merge(member_of_collection_ids: [collection_id]) if collection_id
 
         actor_env  = Hyrax::Actors::Environment.new(created,
                                                     ::Ability.new(@creator),

--- a/spec/darlingtonia/hyrax_record_importer_spec.rb
+++ b/spec/darlingtonia/hyrax_record_importer_spec.rb
@@ -10,6 +10,20 @@ describe Darlingtonia::HyraxRecordImporter, :clean do
   let(:info_stream)  { [] }
   let(:record)       { Darlingtonia::InputRecord.from(metadata: metadata) }
 
+  context 'collection id' do
+    subject(:importer) do
+      described_class.new(collection_id: collection_id)
+    end
+    let(:collection_id) { '123' }
+
+    load File.expand_path("../../support/shared_contexts/with_work_type.rb", __FILE__)
+    include_context 'with a work type'
+
+    it 'can have a collection id' do
+      expect(importer.collection_id).to eq collection_id
+    end
+  end
+
   context 'with no attached files' do
     let(:metadata) do
       {


### PR DESCRIPTION
Connected to curationexperts/tenejo#101