### PR TITLE
Address Hyrax deprecation warning

### DIFF
--- a/lib/darlingtonia/hyrax_record_importer.rb
+++ b/lib/darlingtonia/hyrax_record_importer.rb
@@ -97,7 +97,7 @@ module Darlingtonia
         created    = import_type.new
 
         attributes = record.attributes.merge(uploaded_files)
-        attributes = attributes.merge(member_of_collection_ids: [collection_id]) if collection_id
+        attributes = attributes.merge(member_of_collections_attributes: { '0' => { id: collection_id } }) if collection_id
 
         actor_env  = Hyrax::Actors::Environment.new(created,
                                                     ::Ability.new(@creator),


### PR DESCRIPTION
Update member_of_collection_ids to member_of_collection_attributes to
address Hyrax deprecation warning and make us compatible with Hyrax 3.0.

Also note that member_of_collection_attributes now must take a Hash. See
https://github.com/samvera/hyrax/blob/b6e511d42bb6466c9f2c9b480ca79d2fe60e5453/spec/actors/hyrax/actors/collections_membership_actor_spec.rb#L22

Connected to https://github.com/curationexperts/tenejo/issues/121