### PR TITLE
Refactor of location mapping

### DIFF
--- a/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
+++ b/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
@@ -70,58 +70,6 @@ module Darlingtonia
     end
 
     ##
-    # When submitting location data (a.k.a. the "based near" attribute) via the UI,
-    # Hyrax expects to receive a `based_near_attributes` hash in a specific format.
-    # We need to take geonames urls as provided by the customer and transform them to
-    # mimic what the Hyrax UI would ordinarily produce. These will get turned into
-    # Hyrax::ControlledVocabularies::Location objects upon ingest.
-    # The expected hash looks like this:
-    # {
-    #   "based_near_attributes"=>
-    #     {
-    #       "0"=> {
-    #               "hidden_label"=>"Montana",
-    #               "id"=>"http://sws.geonames.org/5667009/", "_destroy"=>""
-    #             },
-    #       "1"=> {
-    #               "hidden_label"=>"United States",
-    #               "id"=>"http://sws.geonames.org/6252001/", "_destroy"=>""
-    #             },
-    #   }
-    # }
-    # @return [Hash] a "based_near_attributes" hash as
-    def based_near
-      original_geonames_uris = map_field('location')
-      return if original_geonames_uris.empty?
-      based_near_attributes = { "based_near_attributes" => {} }
-      original_geonames_uris.each_with_index do |uri, i|
-        based_near_attributes["based_near_attributes"][i.to_s] = { "hidden_label" => uri_to_hidden_label(uri), "id" => uri_to_sws(uri), "_destroy" => "" }
-      end
-      based_near_attributes
-    end
-
-    #
-    # Take a geonames URI and return a label. This should be the last bit of the uri
-    # (e.g., "montana.html") with the .html removed and the remaining part titleized.
-    # @param [String] uri
-    # @return [String] a place name
-    def uri_to_hidden_label(uri)
-      uri = URI(uri)
-      uri.path.split('/')[-1].gsub('.html', '').tr('-', ' ').titleize
-    end
-
-    #
-    # Take a user-facing geonames URI and return an sws URI, of the form Hyrax expects
-    # (e.g., "http://sws.geonames.org/6252001/")
-    # @param [String] uri
-    # @return [String] an sws style geonames uri
-    def uri_to_sws(uri)
-      uri = URI(uri)
-      geonames_number = uri.path.split('/')[1]
-      "http://sws.geonames.org/#{geonames_number}/"
-    end
-
-    ##
     # @return [String] The delimiter that will be used to split a metadata field into separate values.
     # @example
     #   mapper = HyraxBasicMetadataMapper.new

--- a/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
+++ b/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
@@ -142,46 +142,5 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
         expect(mapper.depositor).to eq nil
       end
     end
-
-    # When submitting location data (a.k.a., the "based near" attribute) via the UI,
-    # Hyrax expects to receive a `based_near_attributes` hash in a specific format.
-    # We need to take geonames urls as provided by the customer and transform them to
-    # mimic what the Hyrax UI would ordinarily produce. These will get turned into
-    # Hyrax::ControlledVocabularies::Location objects upon ingest.
-    context 'with location uris' do
-      before { mapper.metadata = metadata }
-      let(:metadata) do
-        {
-          'title' => 'A Title',
-          'language' => 'English',
-          'visibility' => 'open',
-          'location' => 'http://www.geonames.org/5667009/montana.html|~|http://www.geonames.org/6252001/united-states.html'
-        }
-      end
-      let(:expected_bn_hash) do
-        {
-          "based_near_attributes" =>
-            {
-              "0" => {
-                "hidden_label" => "Montana",
-                "id" => "http://sws.geonames.org/5667009/", "_destroy" => ""
-              },
-              "1" => {
-                "hidden_label" => "United States",
-                "id" => "http://sws.geonames.org/6252001/", "_destroy" => ""
-              }
-            }
-        }
-      end
-      it "gets a label from a geonames uri" do
-        expect(mapper.uri_to_hidden_label("http://www.geonames.org/6252001/united-states.html")).to eq "United States"
-      end
-      it "gets a sws uri from a geonames uri" do
-        expect(mapper.uri_to_sws("http://www.geonames.org/6252001/united-states.html")).to eq "http://sws.geonames.org/6252001/"
-      end
-      it 'transforms an array of geonames uris into the expected based_near_attributes hash' do
-        expect(mapper.based_near).to eq expected_bn_hash
-      end
-    end
   end
 end

--- a/spec/darlingtonia/hyrax_record_importer_spec.rb
+++ b/spec/darlingtonia/hyrax_record_importer_spec.rb
@@ -128,4 +128,28 @@ describe Darlingtonia::HyraxRecordImporter, :clean do
       end
     end
   end
+  # When submitting location data (a.k.a., the "based near" attribute) via the UI,
+  # Hyrax expects to receive a `based_near_attributes` hash in a specific format.
+  # We need to take geonames urls as provided by the customer and transform them to
+  # mimic what the Hyrax UI would ordinarily produce. These will get turned into
+  # Hyrax::ControlledVocabularies::Location objects upon ingest.
+  context 'with location uris' do
+    let(:based_near) { ['http://www.geonames.org/5667009/montana.html', 'http://www.geonames.org/6252001/united-states.html'] }
+    let(:expected_bn_hash) do
+      {
+        "0" => {
+          "id" => "http://sws.geonames.org/5667009/", "_destroy" => ""
+        },
+        "1" => {
+          "id" => "http://sws.geonames.org/6252001/", "_destroy" => ""
+        }
+      }
+    end
+    it "gets a sws uri from a geonames uri" do
+      expect(importer.uri_to_sws("http://www.geonames.org/6252001/united-states.html")).to eq "http://sws.geonames.org/6252001/"
+    end
+    it 'transforms an array of geonames uris into the expected based_near_attributes hash' do
+      expect(importer.based_near_attributes(based_near)).to eq expected_bn_hash
+    end
+  end
 end

--- a/spec/support/shared_contexts/with_work_type.rb
+++ b/spec/support/shared_contexts/with_work_type.rb
@@ -8,6 +8,7 @@ shared_context 'with a work type' do
 
     class Work < ActiveFedora::Base
       attr_accessor :visibility
+      attr_accessor :based_near_attributes
       include ::Hyrax::CoreMetadata
       include ::Hyrax::BasicMetadata
     end


### PR DESCRIPTION
GeoNames location mapping has to happen right before import and the
attributes we pass to the actor stack have to be changed.

Connected to https://github.com/curationexperts/tenejo/issues/135