### PR TITLE
Add a default LogStream class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ Gemfile.lock
 .byebug_history
 .fcrepo_wrapper_test.yml
 .solr_wrapper_test.yml
+darlingtonia_import.log
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*

--- a/lib/darlingtonia.rb
+++ b/lib/darlingtonia.rb
@@ -33,6 +33,7 @@ module Darlingtonia
   end
   module_function :config
 
+  require 'darlingtonia/log_stream'
   ##
   # Module-wide options for `Darlingtonia`.
   class Configuration
@@ -44,8 +45,8 @@ module Darlingtonia
     attr_accessor :default_error_stream, :default_info_stream
 
     def initialize
-      self.default_error_stream = STDOUT
-      self.default_info_stream  = STDOUT
+      self.default_error_stream = Darlingtonia::LogStream.new
+      self.default_info_stream  = Darlingtonia::LogStream.new
     end
   end
 

--- a/lib/darlingtonia/log_stream.rb
+++ b/lib/darlingtonia/log_stream.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Darlingtonia
+  class LogStream
+    ##
+    # @!attribute [rw] logger
+    #   @return [Logger]
+    # @!attribute [rw] severity
+    #   @return [Logger::Serverity]
+    attr_accessor :logger, :severity
+
+    def initialize(logger: nil, severity: nil)
+      self.logger   = logger   || Logger.new(build_filename)
+      self.severity = severity || Logger::INFO
+    end
+
+    def <<(msg)
+      logger.add(severity, msg)
+      STDOUT << msg
+    end
+
+    private
+
+      def build_filename
+        return ENV['IMPORT_LOG'] if ENV['IMPORT_LOG']
+        return rails_log_name if rails_log_name
+        return './darlingtonia_import.log' unless rails_log_name
+      end
+
+      def rails_log_name
+        case Rails.env
+        when 'production'
+          Rails.root.join('log', "csv_import.log").to_s
+        when 'development'
+          Rails.root.join('log', "dev_csv_import.log").to_s
+        when 'test'
+          Rails.root.join('log', "test_csv_import.log").to_s
+        end
+      rescue NameError
+        false
+      end
+  end
+end

--- a/spec/darlingtonia_spec.rb
+++ b/spec/darlingtonia_spec.rb
@@ -5,21 +5,15 @@ require 'spec_helper'
 describe Darlingtonia do
   describe '#config' do
     it 'can set a default error stream' do
-      stream = []
-
-      expect { described_class.config { |c| c.default_error_stream = stream } }
+      expect { described_class.config { |c| c.default_error_stream = STDOUT } }
         .to change { described_class.config.default_error_stream }
-        .from(STDOUT)
-        .to(stream)
+        .to(STDOUT)
     end
 
     it 'can set a default info stream' do
-      stream = []
-
-      expect { described_class.config { |c| c.default_info_stream = stream } }
+      expect { described_class.config { |c| c.default_info_stream = STDOUT } }
         .to change { described_class.config.default_info_stream }
-        .from(STDOUT)
-        .to(stream)
+        .to(STDOUT)
     end
   end
 end


### PR DESCRIPTION
This adds a class that will be used by Darlingtonia
for logging instead of defaulting to STDOUT.

Connected to curationexperts/tenejo#67