### PR TITLE
Visibility input should match Hyrax UI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,10 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - 'lib/darlingtonia/spec/**/*'
 
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - lib/darlingtonia/hyrax_basic_metadata_mapper.rb
+
 Metrics/LineLength:
   Exclude:
     - 'lib/darlingtonia/hyrax_basic_metadata_mapper.rb'

--- a/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
+++ b/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
@@ -73,6 +73,10 @@ module Darlingtonia
         'registered'
       when "authenticated"
         'registered'
+      when ::Hyrax::Institution.name&.downcase&.gsub(/\s+/, "")
+        'registered'
+      when ::Hyrax::Institution.name_full&.downcase&.gsub(/\s+/, "")
+        'registered'
       when 'private'
         'restricted'
       when 'restricted'

--- a/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
+++ b/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
@@ -61,8 +61,25 @@ module Darlingtonia
       single_value('import_url')
     end
 
+    # We should accept visibility values that match the UI and transform them into
+    # the controlled vocabulary term expected by Hyrax
     def visibility
-      single_value('visibility')
+      case metadata[matching_header('visibility')]&.downcase&.gsub(/\s+/, "")
+      when 'public'
+        'open'
+      when 'open'
+        'open'
+      when 'registered'
+        'registered'
+      when "authenticated"
+        'registered'
+      when 'private'
+        'restricted'
+      when 'restricted'
+        'restricted'
+      else
+        'restricted' # This is the default if nothing else matches
+      end
     end
 
     def files

--- a/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
+++ b/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
@@ -131,6 +131,8 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
     end
 
     context 'Visibility values in the CSV should match the Edit UI' do
+      load File.expand_path("../../support/shared_contexts/with_work_type.rb", __FILE__)
+      include_context 'with a work type'
       context 'public is a synonym for open' do
         before { mapper.metadata = metadata }
         let(:metadata) do
@@ -143,6 +145,34 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
           expect(mapper.title).to eq ['A Title']
           expect(mapper.related_url).to eq ['http://example.com']
           expect(mapper.visibility).to eq 'open'
+        end
+      end
+      context 'institution name is a synonym for registered' do
+        before { mapper.metadata = metadata }
+        let(:metadata) do
+          { ' Title ' => 'A Title',
+            " Related URL \n " => 'http://example.com',
+            ' visiBILITY ' => 'my_institution' }
+        end
+
+        it 'transforms public to open regardless of capitalization' do
+          expect(mapper.title).to eq ['A Title']
+          expect(mapper.related_url).to eq ['http://example.com']
+          expect(mapper.visibility).to eq 'registered'
+        end
+      end
+      context 'full institution name is a synonym for registered' do
+        before { mapper.metadata = metadata }
+        let(:metadata) do
+          { ' Title ' => 'A Title',
+            " Related URL \n " => 'http://example.com',
+            ' visiBILITY ' => 'my full institution name' }
+        end
+
+        it 'transforms public to open regardless of capitalization' do
+          expect(mapper.title).to eq ['A Title']
+          expect(mapper.related_url).to eq ['http://example.com']
+          expect(mapper.visibility).to eq 'registered'
         end
       end
     end

--- a/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
+++ b/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
@@ -130,6 +130,23 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
       end
     end
 
+    context 'Visibility values in the CSV should match the Edit UI' do
+      context 'public is a synonym for open' do
+        before { mapper.metadata = metadata }
+        let(:metadata) do
+          { ' Title ' => 'A Title',
+            " Related URL \n " => 'http://example.com',
+            ' visiBILITY ' => 'PubLIC' }
+        end
+
+        it 'transforms public to open regardless of capitalization' do
+          expect(mapper.title).to eq ['A Title']
+          expect(mapper.related_url).to eq ['http://example.com']
+          expect(mapper.visibility).to eq 'open'
+        end
+      end
+    end
+
     # When someone accidentally has too many commas in the CSV rows
     context 'headers with a nil' do
       before { mapper.metadata = metadata }

--- a/spec/darlingtonia/importer_spec.rb
+++ b/spec/darlingtonia/importer_spec.rb
@@ -3,6 +3,9 @@
 require 'spec_helper'
 
 describe Darlingtonia::Importer do
+  load File.expand_path("../../support/shared_contexts/with_work_type.rb", __FILE__)
+  include_context 'with a work type'
+
   subject(:importer) { described_class.new(parser: parser) }
   let(:parser)       { FakeParser.new(file: input) }
   let(:input)        { [{ 'title' => '1' }, { 'title' => '2' }, { 'title' => '3' }] }

--- a/spec/darlingtonia/input_record_spec.rb
+++ b/spec/darlingtonia/input_record_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 describe Darlingtonia::InputRecord do
+  load File.expand_path("../../support/shared_contexts/with_work_type.rb", __FILE__)
+  include_context 'with a work type'
   subject(:record) { described_class.from(metadata: metadata) }
 
   let(:metadata) do

--- a/spec/support/shared_contexts/with_work_type.rb
+++ b/spec/support/shared_contexts/with_work_type.rb
@@ -43,6 +43,16 @@ shared_context 'with a work type' do
         end
       end
 
+      class Institution
+        def self.name
+          'my_institution'
+        end
+
+        def self.name_full
+          'my full institution name'
+        end
+      end
+
       class UploadedFile < ActiveFedora::Base
         def self.create(*)
           h = Hyrax::UploadedFile.new


### PR DESCRIPTION
Allow visibility input to match 'public' and 'authenticated' and
'private' and map those values to their expected Hyrax controlled
vocabulary equivalents.

Connected to https://github.com/curationexperts/tenejo/issues/115