### PR TITLE
Remove date_uploaded

### DIFF
--- a/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
+++ b/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
@@ -41,10 +41,6 @@ module Darlingtonia
       single_value('depositor')
     end
 
-    def date_uploaded
-      single_value('date_uploaded')
-    end
-
     def date_modified
       single_value('date_modified')
     end
@@ -131,8 +127,12 @@ module Darlingtonia
       end
 
       # Properties defined in Hyrax::CoreMetadata
+      # Note that date_uploaded is NOT set here, even though it is defined in
+      # Hyrax::CoreMetadata. Hyrax expects to set date_uploaded itself, and
+      # sending a metadata value for that field interferes with Hyrax expected
+      # behavior.
       def core_fields
-        [:depositor, :title, :date_uploaded, :date_modified]
+        [:depositor, :title, :date_modified]
       end
 
       # Properties defined in Hyrax::BasicMetadata

--- a/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
+++ b/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
@@ -6,7 +6,7 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
 
   # Properties defined in Hyrax::CoreMetadata
   let(:core_fields) do
-    [:depositor, :title, :date_uploaded, :date_modified]
+    [:depositor, :title, :date_modified]
   end
 
   # Properties defined in Hyrax::BasicMetadata
@@ -49,7 +49,6 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
 
     it 'returns single values for single-value fields' do
       expect(mapper.depositor).to eq 'someone@example.org'
-      expect(mapper.date_uploaded).to eq nil
       expect(mapper.date_modified).to eq nil
       expect(mapper.label).to eq nil
       expect(mapper.relative_path).to eq nil
@@ -93,7 +92,6 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
           'Abstract or Summary' => 'desc1|~|desc2',
           'visiBILITY' => 'open',
           'Depositor' => 'someone@example.org',
-          'DATE_uploaded' => 'up date',
           'DATE_modified' => 'mod date',
           'laBel' => 'label',
           'relative_PATH' => 'rel path',
@@ -107,7 +105,6 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
         expect(mapper.creator).to eq []
         expect(mapper.visibility).to eq 'open'
         expect(mapper.depositor).to eq 'someone@example.org'
-        expect(mapper.date_uploaded).to eq 'up date'
         expect(mapper.date_modified).to eq 'mod date'
         expect(mapper.label).to eq 'label'
         expect(mapper.relative_path).to eq 'rel path'

--- a/spec/fixtures/hyrax/example.csv
+++ b/spec/fixtures/hyrax/example.csv
@@ -1,3 +1,3 @@
-title,depositor,date_uploaded,date_modified,label,relative_path,import_url,resource type,creator,contributor,abstract or summary,keyword,license,rights statement,publisher,date created,subject,language,identifier,location,related url,bibliographic_citation,source
-Work 1 Title,user@example.com,2018-12-21,2018-01-01,Work 1 Label,tmp/files,https://example.com,Work 1 Type,Work 1 creator,Work 1 contrib,Desc 1,Key 1,Lic 1,RS 1,Pub 1,2018-06-06,Subj 1,English|~|Japanese,Ident 1,Based 1,https://example.com/related,Bib 1,Source 1
-Work 2 Title,,1970-12-21,,Work 2 Label,,,Work 2 Type,,,Desc 2,,,,Pub 2,,Subj 2
+title,depositor,date_modified,label,relative_path,import_url,resource type,creator,contributor,abstract or summary,keyword,license,rights statement,publisher,date created,subject,language,identifier,location,related url,bibliographic_citation,source
+Work 1 Title,user@example.com,2018-01-01,Work 1 Label,tmp/files,https://example.com,Work 1 Type,Work 1 creator,Work 1 contrib,Desc 1,Key 1,Lic 1,RS 1,Pub 1,2018-06-06,Subj 1,English|~|Japanese,Ident 1,Based 1,https://example.com/related,Bib 1,Source 1
+Work 2 Title,1970-12-21,,Work 2 Label,,,Work 2 Type,,,Desc 2,,,,Pub 2,,Subj 2

--- a/spec/integration/import_hyrax_csv.rb
+++ b/spec/integration/import_hyrax_csv.rb
@@ -21,7 +21,6 @@ describe 'importing a CSV with Hyrax defaults', :clean do
 
     # First Record
     expect(work1.depositor).to eq 'batchuser@example.com'
-    expect(work1.date_uploaded).to eq '2018-12-21'
     expect(work1.date_modified).to eq '2018-01-01'
     expect(work1.label).to eq 'Work 1 Label'
     expect(work1.relative_path).to eq 'tmp/files'
@@ -48,7 +47,6 @@ describe 'importing a CSV with Hyrax defaults', :clean do
 
     # Second Record
     expect(work2.depositor).to eq 'batchuser@example.com'
-    expect(work2.date_uploaded).to eq '1970-12-21'
     expect(work2.date_modified).to be_nil
     expect(work2.label).to eq 'Work 2 Label'
     expect(work2.relative_path).to be_nil


### PR DESCRIPTION
We should not pass `date_uploaded` in via the metadata. Hyrax expects to
set this value itself, and if we include it in our metadata fields we
write over Hyrax's timestamp with a nil value or a string value, causing
application errors.

Connected to https://github.com/curationexperts/tenejo/issues/166