### PR TITLE
Institution-only == authenticated, not registered

### DIFF
--- a/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
+++ b/lib/darlingtonia/hyrax_basic_metadata_mapper.rb
@@ -70,13 +70,13 @@ module Darlingtonia
       when 'open'
         'open'
       when 'registered'
-        'registered'
+        'authenticated'
       when "authenticated"
-        'registered'
+        'authenticated'
       when ::Hyrax::Institution.name&.downcase&.gsub(/\s+/, "")
-        'registered'
+        'authenticated'
       when ::Hyrax::Institution.name_full&.downcase&.gsub(/\s+/, "")
-        'registered'
+        'authenticated'
       when 'private'
         'restricted'
       when 'restricted'

--- a/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
+++ b/spec/darlingtonia/hyrax_basic_metadata_mapper_spec.rb
@@ -147,7 +147,7 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
           expect(mapper.visibility).to eq 'open'
         end
       end
-      context 'institution name is a synonym for registered' do
+      context 'institution name is a synonym for authenticated' do
         before { mapper.metadata = metadata }
         let(:metadata) do
           { ' Title ' => 'A Title',
@@ -155,13 +155,13 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
             ' visiBILITY ' => 'my_institution' }
         end
 
-        it 'transforms public to open regardless of capitalization' do
+        it 'transforms institution name to authenticated regardless of capitalization' do
           expect(mapper.title).to eq ['A Title']
           expect(mapper.related_url).to eq ['http://example.com']
-          expect(mapper.visibility).to eq 'registered'
+          expect(mapper.visibility).to eq 'authenticated'
         end
       end
-      context 'full institution name is a synonym for registered' do
+      context 'full institution name is a synonym for authenticated' do
         before { mapper.metadata = metadata }
         let(:metadata) do
           { ' Title ' => 'A Title',
@@ -169,10 +169,10 @@ describe Darlingtonia::HyraxBasicMetadataMapper do
             ' visiBILITY ' => 'my full institution name' }
         end
 
-        it 'transforms public to open regardless of capitalization' do
+        it 'transforms full institution name to authenticated regardless of capitalization' do
           expect(mapper.title).to eq ['A Title']
           expect(mapper.related_url).to eq ['http://example.com']
-          expect(mapper.visibility).to eq 'registered'
+          expect(mapper.visibility).to eq 'authenticated'
         end
       end
     end


### PR DESCRIPTION
The value of Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED is authenticated, not registered. This PR fixes a bug that would otherwise prevent proper visibility assignment.

Connected to curationexperts/tenejo#115