### PR TITLE
Improving our logging

### DIFF
--- a/lib/darlingtonia/importer.rb
+++ b/lib/darlingtonia/importer.rb
@@ -34,6 +34,7 @@ module Darlingtonia
     def initialize(parser:, record_importer: RecordImporter.new)
       self.parser          = parser
       self.record_importer = record_importer
+      @info_stream = Darlingtonia.config.default_info_stream
     end
 
     ##
@@ -42,6 +43,7 @@ module Darlingtonia
     # @return [void]
     def import
       records.each { |record| record_importer.import(record: record) }
+      @info_stream << "event: finish_import, batch_id: #{record_importer.batch_id}, successful_record_count: #{record_importer.success_count}, failed_record_count: #{record_importer.failure_count}"
     end
   end
 end

--- a/lib/darlingtonia/record_importer.rb
+++ b/lib/darlingtonia/record_importer.rb
@@ -7,7 +7,13 @@ module Darlingtonia
     #   @return [#<<]
     # @!attribute [rw] info_stream
     #   @return [#<<]
-    attr_accessor :error_stream, :info_stream
+    # @!attribute [rw] batch_id
+    #   @return [String] an optional batch id for this import run
+    # @!attribute [rw] success_count
+    #   @return [Integer] a count of the records that were successfully created
+    # @!attribute [rw] failure_count
+    #   @return [Integer] a count of the records that failed import
+    attr_accessor :error_stream, :info_stream, :batch_id, :success_count, :failure_count
 
     ##
     # @param error_stream [#<<]

--- a/spec/darlingtonia/importer_spec.rb
+++ b/spec/darlingtonia/importer_spec.rb
@@ -12,6 +12,8 @@ describe Darlingtonia::Importer do
 
   let(:fake_record_importer) do
     Class.new do
+      attr_accessor :batch_id, :success_count, :failure_count
+
       def import(record:)
         records << record.attributes
       end


### PR DESCRIPTION
* Make log messages easier to parse.
* Add batch_id, success_count, and failure_count attributes to the record
importer class so we can tally success and failures per import job.
* Report to info_stream the number of successful record creations and the
number of records that failed to import.

Connected to https://github.com/curationexperts/tenejo/issues/186
Connected to https://github.com/curationexperts/tenejo/issues/185
Connected to https://github.com/curationexperts/tenejo/issues/170