### PR TITLE
Ensure that the filename method returns correctly

### DIFF
--- a/lib/darlingtonia.rb
+++ b/lib/darlingtonia.rb
@@ -45,8 +45,8 @@ module Darlingtonia
     attr_accessor :default_error_stream, :default_info_stream
 
     def initialize
-      self.default_error_stream = Darlingtonia::LogStream.new
-      self.default_info_stream  = Darlingtonia::LogStream.new
+      self.default_error_stream = Darlingtonia::LogStream.new(severity: Logger::ERROR)
+      self.default_info_stream  = Darlingtonia::LogStream.new(severity: Logger::INFO)
     end
   end
 

--- a/lib/darlingtonia/log_stream.rb
+++ b/lib/darlingtonia/log_stream.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require 'byebug'
 module Darlingtonia
   class LogStream
     ##
@@ -23,21 +23,22 @@ module Darlingtonia
 
       def build_filename
         return ENV['IMPORT_LOG'] if ENV['IMPORT_LOG']
-        return rails_log_name if rails_log_name
-        return './darlingtonia_import.log' unless rails_log_name
+        rails_log_name
       end
 
       def rails_log_name
-        case Rails.env
+        case ENV['RAILS_ENV']
         when 'production'
           Rails.root.join('log', "csv_import.log").to_s
         when 'development'
           Rails.root.join('log', "dev_csv_import.log").to_s
         when 'test'
           Rails.root.join('log', "test_csv_import.log").to_s
+        when nil
+          './darlingtonia_import.log'
         end
       rescue NameError
-        false
+        './darlingtonia_import.log'
       end
   end
 end


### PR DESCRIPTION
This adds additional checking for the `build_file_name` method
to ensure that it generates a correct file name in different
environments.

This is required for curationexperts/tenejo#167