### PR TITLE
Allow subclassed libraries not to have a files field

### DIFF
--- a/lib/darlingtonia/hyrax_record_importer.rb
+++ b/lib/darlingtonia/hyrax_record_importer.rb
@@ -86,6 +86,7 @@ module Darlingtonia
     # @param [Darlingtonia::InputRecord]
     # @return [Array] an array of Hyrax::UploadedFile ids
     def create_upload_files(record)
+      return unless record.mapper.respond_to?(:files)
       files_to_attach = record.mapper.files
       return [] if files_to_attach.nil? || files_to_attach.empty?
 
@@ -178,7 +179,7 @@ module Darlingtonia
                                                    attrs)
 
         if Hyrax::CurationConcern.actor.create(actor_env)
-          info_stream << "event: record_created, batch_id: #{batch_id}, record_id: #{created.id}, collection_id: #{collection_id}, record_title: #{attrs[:title].first}"
+          info_stream << "event: record_created, batch_id: #{batch_id}, record_id: #{created.id}, collection_id: #{collection_id}, record_title: #{attrs[:title]&.first}"
           @success_count += 1
         else
           created.errors.each do |attr, msg|

--- a/spec/darlingtonia/hyrax_record_importer_spec.rb
+++ b/spec/darlingtonia/hyrax_record_importer_spec.rb
@@ -40,6 +40,29 @@ describe Darlingtonia::HyraxRecordImporter, :clean do
     end
   end
 
+  # Instead of having a files field in the mapper, which will create a
+  # Hyrax::UploadedFile for each file before attaching it, some importers will
+  # use a remote_files strategy and instead treat each file as a remote file and
+  # fetch it at object creation time. This might be faster, and we might eventually
+  # want to adopt it as our default. For now, do not raise an error if there is no
+  # `files` field in the mapper being used.
+  context 'with no files filed in the mapper' do
+    let(:metadata) do
+      {
+        'title' => 'A Title',
+        'language' => 'English',
+        'visibility' => 'open'
+      }
+    end
+    let(:record) { Darlingtonia::InputRecord.from(metadata: metadata, mapper: Darlingtonia::MetadataMapper.new) }
+
+    it 'creates a work for record' do
+      expect { importer.import(record: record) }
+        .to change { Work.count }
+        .by 1
+    end
+  end
+
   context 'with attached files' do
     before do
       ENV['IMPORT_PATH'] = File.expand_path('../fixtures/images', File.dirname(__FILE__))


### PR DESCRIPTION
It should be fine to use HyraxRecordImporter with a customized mapper
that does not contain a field called `files`. There are other strategies
for attaching files, such as the remote_files strategy used at UCLA in
the Californica project.

Connected to https://github.com/UCLALibrary/californica/issues/339