### PR TITLE
Search for depositor by user key

### DIFF
--- a/lib/darlingtonia/hyrax_record_importer.rb
+++ b/lib/darlingtonia/hyrax_record_importer.rb
@@ -48,8 +48,9 @@ module Darlingtonia
     # "depositor" is a required field for Hyrax.  If
     # it hasn't been set, set it to the Hyrax default
     # batch user.
-    def set_depositor(user_id)
-      user = User.find(user_id) if user_id
+    def set_depositor(user_key)
+      user = ::User.find_by_user_key(user_key) if user_key
+      user ||= ::User.find(user_key) if user_key
       user ||= ::User.find_or_create_system_user(DEFAULT_CREATOR_KEY)
       self.depositor = user
     end

--- a/spec/darlingtonia/hyrax_record_importer_spec.rb
+++ b/spec/darlingtonia/hyrax_record_importer_spec.rb
@@ -128,7 +128,7 @@ describe Darlingtonia::HyraxRecordImporter, :clean do
     end
 
     context 'when depositor is passed to initializer' do
-      subject(:importer) { described_class.new(error_stream: error_stream, info_stream: info_stream, attributes: { depositor_id: user.id }) }
+      subject(:importer) { described_class.new(error_stream: error_stream, info_stream: info_stream, attributes: { depositor_id: user.user_key }) }
 
       let(:user) { ::User.new(id: '123', user_key: 'special_user@example.com') }
       before { allow(::User).to receive(:find).and_return(user) }

--- a/spec/support/shared_contexts/with_work_type.rb
+++ b/spec/support/shared_contexts/with_work_type.rb
@@ -19,6 +19,10 @@ shared_context 'with a work type' do
         self.user_key = inputs[:user_key] || batch_user_key
       end
 
+      def self.find_by_user_key(email)
+        User.new(user_key: email)
+      end
+
       def self.find_or_create_system_user(_email)
         User.new
       end


### PR DESCRIPTION
Expect that we will specify the depositor by user key, since that's the
general practice in Hyrax. Fall back to querying for depositor by id for
backward compatibility.

Connected to https://github.com/UCLALibrary/californica/issues/395