### PR TITLE
Update a record if it matches on a given field

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,18 +21,25 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - 'lib/darlingtonia/spec/**/*'
 
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
   Exclude:
     - lib/darlingtonia/hyrax_basic_metadata_mapper.rb
+    - lib/darlingtonia/hyrax_record_importer.rb
 
 Metrics/LineLength:
-  Exclude:
-    - 'lib/darlingtonia/hyrax_basic_metadata_mapper.rb'
+  Enabled: false
 
 Metrics/MethodLength:
   Exclude:
     - 'spec/support/hyrax/basic_metadata.rb'
     - 'lib/darlingtonia/hyrax_basic_metadata_mapper.rb'
+    - lib/darlingtonia/hyrax_record_importer.rb
+
+Metrics/PerceivedComplexity:
+  Exclude:
     - lib/darlingtonia/hyrax_record_importer.rb
 
 Naming/AccessorMethodName:

--- a/lib/darlingtonia/hyrax_record_importer.rb
+++ b/lib/darlingtonia/hyrax_record_importer.rb
@@ -72,6 +72,8 @@ module Darlingtonia
     # Search for any existing records that match on the deduplication_field
     def find_existing_record(record)
       return unless deduplication_field
+      return unless record.respond_to?(deduplication_field)
+      return if record.mapper.send(deduplication_field).empty?
       existing_records = import_type.where("#{deduplication_field}": record.mapper.send(deduplication_field).to_s)
       raise "More than one record matches deduplication_field #{deduplication_field} with value #{record.mapper.send(deduplication_field)}" if existing_records.count > 1
       existing_records&.first


### PR DESCRIPTION
Allow importer to define a deduplication field that will be used to
check existing records. If there is an existing record matching the
dedpulication_field value, update that record's metadata instead of
making a new record.

Note that this will not import (or re-import) file attachments.

Connected to https://github.com/UCLALibrary/californica/issues/403