### PR TITLE
Pare down the update actor stack

### DIFF
--- a/lib/darlingtonia.rb
+++ b/lib/darlingtonia.rb
@@ -69,4 +69,5 @@ module Darlingtonia
 
   require 'darlingtonia/parser'
   require 'darlingtonia/parsers/csv_parser'
+  require 'darlingtonia/metadata_only_stack'
 end

--- a/lib/darlingtonia/importer.rb
+++ b/lib/darlingtonia/importer.rb
@@ -38,17 +38,24 @@ module Darlingtonia
       @error_stream = error_stream
     end
 
+    # Do not attempt to run an import if there are no records. Instead, just write to the log.
+    def no_records_message
+      @info_stream << "event: empty_import, batch_id: #{record_importer.batch_id}"
+      @error_stream << "event: empty_import, batch_id: #{record_importer.batch_id}"
+    end
+
     ##
     # Import each record in {#records}.
     #
     # @return [void]
     def import
-      start_time = Time.zone.now
+      no_records_message && return unless records.count.positive?
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       @info_stream << "event: start_import, batch_id: #{record_importer.batch_id}, expecting to import #{records.count} records."
       records.each { |record| record_importer.import(record: record) }
-      end_time = Time.zone.now
+      end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       elapsed_time = end_time - start_time
-      @info_stream << "event: finish_import, batch_id: #{record_importer.batch_id}, successful_record_count: #{record_importer.success_count}, failed_record_count: #{record_importer.failure_count}, elapsed_time: #{elapsed_time}, elapsed_time_per_record: #{elapsed_time/records.count}"
+      @info_stream << "event: finish_import, batch_id: #{record_importer.batch_id}, successful_record_count: #{record_importer.success_count}, failed_record_count: #{record_importer.failure_count}, elapsed_time: #{elapsed_time}, elapsed_time_per_record: #{elapsed_time / records.count}"
     end
   end
 end

--- a/lib/darlingtonia/importer.rb
+++ b/lib/darlingtonia/importer.rb
@@ -31,10 +31,11 @@ module Darlingtonia
     #   records.
     # @param record_importer [RecordImporter] An object to handle import of
     #   each record
-    def initialize(parser:, record_importer: RecordImporter.new)
+    def initialize(parser:, record_importer: RecordImporter.new, info_stream: Darlingtonia.config.default_info_stream, error_stream: Darlingtonia.config.default_error_stream)
       self.parser          = parser
       self.record_importer = record_importer
-      @info_stream = Darlingtonia.config.default_info_stream
+      @info_stream = info_stream
+      @error_stream = error_stream
     end
 
     ##
@@ -42,8 +43,12 @@ module Darlingtonia
     #
     # @return [void]
     def import
+      start_time = Time.zone.now
+      @info_stream << "event: start_import, batch_id: #{record_importer.batch_id}, expecting to import #{records.count} records."
       records.each { |record| record_importer.import(record: record) }
-      @info_stream << "event: finish_import, batch_id: #{record_importer.batch_id}, successful_record_count: #{record_importer.success_count}, failed_record_count: #{record_importer.failure_count}"
+      end_time = Time.zone.now
+      elapsed_time = end_time - start_time
+      @info_stream << "event: finish_import, batch_id: #{record_importer.batch_id}, successful_record_count: #{record_importer.success_count}, failed_record_count: #{record_importer.failure_count}, elapsed_time: #{elapsed_time}, elapsed_time_per_record: #{elapsed_time/records.count}"
     end
   end
 end

--- a/lib/darlingtonia/metadata_only_stack.rb
+++ b/lib/darlingtonia/metadata_only_stack.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Darlingtonia
+  class MetadataOnlyStack
+    def self.build_stack
+      ActionDispatch::MiddlewareStack.new.tap do |middleware|
+        # Wrap everything in a database transaction, if the save of the resource
+        # fails then roll back any database AdminSetChangeSet
+        middleware.use Hyrax::Actors::TransactionalRequest
+
+        # Ensure you are mutating the most recent version
+        # middleware.use Hyrax::Actors::OptimisticLockValidator
+
+        # Attach files from a URI (for BrowseEverything)
+        # middleware.use Hyrax::Actors::CreateWithRemoteFilesActor
+
+        # Attach files uploaded in the form to the UploadsController
+        # In Californica, for command line import,
+        # we are using the CreateWithFilesActor to attach
+        # local files with a file:// url, not via the UploadsController,
+        # so we never use the CreateWithFilesActor
+        # middleware.use Hyrax::Actors::CreateWithFilesActor
+
+        # Add/remove the resource to/from a collection
+        middleware.use Hyrax::Actors::CollectionsMembershipActor
+
+        # Add/remove to parent work
+        # middleware.use Hyrax::Actors::AddToWorkActor
+
+        # Add/remove children (works or file_sets)
+        # middleware.use Hyrax::Actors::AttachMembersActor
+
+        # Set the order of the children (works or file_sets)
+        # middleware.use Hyrax::Actors::ApplyOrderActor
+
+        # Sets the default admin set if they didn't supply one
+        # middleware.use Hyrax::Actors::DefaultAdminSetActor
+
+        # Decode the private/public/institution on the form into permisisons on
+        # the model
+        # We aren't using this in Californica, we're just setting the visibility
+        # at import time
+        # middleware.use Hyrax::Actors::InterpretVisibilityActor
+
+        # Handles transfering ownership of works from one user to another
+        # We aren't using this in Californica
+        # middleware.use Hyrax::Actors::TransferRequestActor
+
+        # Copies default permissions from the PermissionTemplate to the work
+        # middleware.use Hyrax::Actors::ApplyPermissionTemplateActor
+
+        # Remove attached FileSets when destroying a work
+        # middleware.use Hyrax::Actors::CleanupFileSetsActor
+
+        # Destroys the trophies in the database when the work is destroyed
+        # middleware.use Hyrax::Actors::CleanupTrophiesActor
+
+        # Destroys the feature tag in the database when the work is destroyed
+        # middleware.use Hyrax::Actors::FeaturedWorkActor
+
+        # Persist the metadata changes on the resource
+        middleware.use Hyrax::Actors::ModelActor
+
+        # Start the workflow for this work
+        # middleware.use Hyrax::Actors::InitializeWorkflowActor
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+end


### PR DESCRIPTION
When a record is imported a second time (i.e., when there is already a
record matching the deduplication field in the repository), only update
its metadata and collection membership. Use a stripped down actor stack
that only performs these actions.

Log a special message if we attempt an empty import.

Fix logging error where id number wasn't printing to logs on updates.

Connected to https://github.com/UCLALibrary/californica/issues/403
